### PR TITLE
Add newer versions of ghc base packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ ghc-base-versions
     * [source](https://www.haskell.org/ghc/docs/7.6.3/html/users_guide/release-7-6-2.html)
 * GHC 7.8.X | base 4.7.0.0
     * [source](https://www.haskell.org/ghc/docs/7.8.3/html/users_guide/release-7-8-1.html)
+* GHC 8.6.5 | base 4.12.0.0
+    * [source](https://downloads.haskell.org/~ghc/8.6.5/docs/html/users_guide/8.6.1-notes.html#included-libraries)
+* GHC 8.8.4 | base 4.13.0.0
+    * [source](https://downloads.haskell.org/~ghc/8.8.4/docs/html/users_guide/8.8.1-notes.html#build-system)
+* GHC 8.10.7 | base 4.14.3.0
+    * [source](https://downloads.haskell.org/~ghc/8.10.7/docs/html/users_guide/8.10.1-notes.html#build-system)
+* GHC 9.0.1 | base 4.15.0.0
+    * [source](https://downloads.haskell.org/~ghc/9.0.1/docs/html/users_guide/9.0.1-notes.html)
+* GHC 9.0.2 | base 4.15.1.0
+    * [source](https://downloads.haskell.org/~ghc/9.0.2/docs/html/users_guide/9.0.1-notes.html)
+* GHC 9.2.5 | base 4.16.4.0
+    * [source](https://downloads.haskell.org/~ghc/9.2.5/docs/html/users_guide/9.2.1-notes.html#base-library)
+* GHC 9.4.3 | base 4.17.0.0
+    * [source](https://downloads.haskell.org/~ghc/9.4.3/docs/users_guide/9.4.1-notes.html#base-library)


### PR DESCRIPTION
I found your library useful when trying to pin down base version 4.14.3.0 so I added the ones I inspected on my travel to the solution 